### PR TITLE
sec + ref: always get Path.basename, update logs and var names

### DIFF
--- a/routes/convert.js
+++ b/routes/convert.js
@@ -11,14 +11,15 @@ module.exports = function (fastify, opts, done) {
   fastify.addContentTypeParser('*', function (request, payload, done) {
     // skip parsing so that the handler has access to the stream
     //request.raw.pause();
-    console.log('rando type?');
+    console.log('[DEBUG] rando type?');
     console.log(request.raw.rawHeaders);
     done();
   });
 
   async function receive(req, name, format = 'pdf') {
-    let dirname = await Fsp.mkdtemp(Path.join(tmpdir, 'libreoffice-convert-'));
-    console.log('tmpdir:', dirname);
+    let tmpPrefix = Path.join(tmpdir, 'laas-source-');
+    let dirname = await Fsp.mkdtemp(tmpPrefix);
+    console.info('[receive] incoming tmpdir:', dirname);
     let dst = Path.join(dirname, name);
     let stream = Fs.createWriteStream(dst);
 
@@ -27,7 +28,7 @@ module.exports = function (fastify, opts, done) {
       req.on('readable', function () {
         let chunk;
         while ((chunk = req.read())) {
-          console.log('chunk', chunk.length);
+          console.log('[DEBUG] chunk.length', chunk.length);
         }
       });
       req.on('error', reject);
@@ -40,8 +41,8 @@ module.exports = function (fastify, opts, done) {
       });
     });
 
-    let pdfPath = await convert(originalPath, format);
-    return pdfPath;
+    let dlPath = await convert(originalPath, format);
+    return dlPath;
   }
 
   // POST /api/convert/:name (ex: report.docx)

--- a/routes/convert.js
+++ b/routes/convert.js
@@ -50,7 +50,7 @@ module.exports = function (fastify, opts, done) {
     let format = request.params.format;
 
     // content-disposition filename hint
-    let filename = request.query.filename;
+    let filename = Path.basename(request.query.filename);
     if (!filename) {
       throw new Error("BAD_REQUEST: 'filename' should be the name of the source file");
     }

--- a/soffice.js
+++ b/soffice.js
@@ -72,11 +72,14 @@ async function convert(inputPath, format, options) {
     inputPath,
   ];
 
-  console.log(cmd, args.join(' '));
+  console.info('[soffice]', cmd, args.join(' '));
   await exec(cmd, args, { TODO_log: false });
-  let basename = Path.basename(inputPath, Path.extname(inputPath));
-  console.log('[soffice] basename:', basename);
-  return Path.join(tmpDir, `${basename}.${format}`);
+
+  let inputExt = Path.extname(inputPath);
+  let basename = Path.basename(inputPath, inputExt);
+  console.info('[soffice] basename:', basename);
+  let outFile = Path.join(tmpDir, `${basename}.${format}`);
+  return outFile;
 }
 
 module.exports = convert;


### PR DESCRIPTION
At first I thought we had a potential vulnerability. We don't - because the path handler already ensures that the path can't be manipulated.

However, this makes it more clear.

Plus a few logging and var name changes.